### PR TITLE
chore: secret key env 전환

### DIFF
--- a/reservationroom/settings.py
+++ b/reservationroom/settings.py
@@ -26,7 +26,7 @@ environ.Env.read_env(env_file=env_file)
 # See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = '2iht1-eoyfbq_ga3nvl*6c*xx!f%f)x^a0@1qsh9ob@x^mkby3'
+SECRET_KEY = env('DJANGO_SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
#### 간결한 설명
- django settings의 secret key를 env 변수로 전환했습니다.

#### 관련 두레이 이슈
- 없음
