### PR TITLE
fix: db update시 end_time기준 필터링, 정렬코드 추가

### DIFF
--- a/events/serializers.py
+++ b/events/serializers.py
@@ -7,13 +7,13 @@ class UserSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 class EventSerializer(serializers.ModelSerializer):
-    users = UserSerializer(required=True, many=True)
+    users = UserSerializer(many=True)
     class Meta:
         model = Events
         fields = '__all__'
 
 class RoomSerializer(serializers.ModelSerializer):
-    events = EventSerializer(required=True, many=True)
+    events = EventSerializer(many=True)
     class Meta:
         model = Rooms
         fields = '__all__'

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ cffi==1.14.5
 chardet==4.0.0
 cryptography==3.4.7
 Django==3.2
+django-cors-headers==3.7.0
 django-environ==0.4.5
 djangorestframework==3.12.4
 idna==2.10


### PR DESCRIPTION
#### 간결한 설명
- end_time 기준으로 이미 끝난 이벤트들은 db update시 반영되지 않게 수정했습니다.
- db update시 들어오는 이벤트들을 end_time기준으로 정렬한 뒤 입력하여 select 시 ordering을 수행하지 않도록 수정했습니다.

#### 관련 두레이 이슈
- 없음
